### PR TITLE
added mariadb-client to the list of installed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN \
  apk add --no-cache \
 	curl \
 	libxml2 \
+	mariadb-client \
 	php7-bcmath \
 	php7-ctype \
 	php7-curl \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -11,6 +11,7 @@ RUN \
  apk add --no-cache \
 	curl \
 	libxml2 \
+	mariadb-client \
 	php7-bcmath \
 	php7-ctype \
 	php7-curl \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -11,6 +11,7 @@ RUN \
  apk add --no-cache \
 	curl \
 	libxml2 \
+	mariadb-client \
 	php7-bcmath \
 	php7-ctype \
 	php7-curl \


### PR DESCRIPTION
Backup in Snipe-IT requires mysqldump, which is provided by mariadb-client on alpine linux.

<!--- Provide a general summary of the issue in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- If you have an issue with the project, please provide us with the following information -->

<!---  Host OS -->
<!--- Command line users, your run/create command, GUI/Unraid users, a screenshot of your template settings. -->
<!--- Docker log output, docker log <container-name>      -->
<!--- Mention if you're using symlinks on any of the volume mounts. -->


<!--- If you have a suggestion or fix for the project, please provide us with the following information -->

<!--- What you think your suggestion brings to the project, or fixes with the project -->
<!--- If it's a fix, would it be better suited as a Pull request to the repo ? -->

##  Thanks, team linuxserver.io


