### PR TITLE
Use linuxserver/mariadb for the database example

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -63,12 +63,15 @@ custom_compose: |
   version: "3"
   services:
     mysql:
-      image: mysql:5
+      image: linuxserver/mariadb
       container_name: snipe_mysql
       restart: always
       volumes:
-        - <path to mysql data>:/var/lib/mysql
+        - <path to mysql data>:/config
       environment:
+        - PUID=1000
+        - PGID=1000
+        - TZ=Europe/London
         - MYSQL_ROOT_PASSWORD=<secret password>
         - MYSQL_USER=snipe
         - MYSQL_PASSWORD=<secret user password>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-snipe-it/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:

The official MySQL Docker image doesn't provide any ARM variants,
so the next best alternative is MariaDB. Since linuxserver has an image, use that.

Closes https://github.com/linuxserver/docker-snipe-it/issues/18

## Benefits of this PR and context:

Avoid confusion by documenting which Docker images work with which architectures. I had to search for a db alternative to work on ARMv7, and then I bumped into https://github.com/linuxserver/docker-snipe-it/issues/18.

## How Has This Been Tested?

Tested on a Raspberry Pi running ARMv7.
