### PR TITLE
Upgrade artisan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.12
+FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.13
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-alpine-nginx:arm64v8-3.12
+FROM ghcr.io/linuxserver/baseimage-alpine-nginx:arm64v8-3.13
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-alpine-nginx:arm32v7-3.12
+FROM ghcr.io/linuxserver/baseimage-alpine-nginx:arm32v7-3.13
 
 # set version label
 ARG BUILD_DATE

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **30.04.21:** - Rebasing to alpine 3.13, add artisan migrate on spinup.
 * **01.06.20:** - Rebasing to alpine 3.12.
 * **19.12.19:** - Rebasing to alpine 3.11.
 * **28.06.19:** - Rebasing to alpine 3.10.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ services:
     volumes:
       - <path to data>:/config
     environment:
-      - APP_URL=< your application URL IE 192.168.10.1:8080>
+      - NGINX_APP_URL=< your application URL IE 192.168.10.1:8080>
       - MYSQL_PORT_3306_TCP_ADDR=mysql
       - MYSQL_PORT_3306_TCP_PORT=3306
       - MYSQL_DATABASE=snipe
@@ -115,7 +115,7 @@ docker run -d \
   --name=snipe-it \
   -e PUID=1000 \
   -e PGID=1000 \
-  -e APP_URL=<hostname or ip> \
+  -e NGINX_APP_URL=<hostname or ip> \
   -e MYSQL_PORT_3306_TCP_ADDR=<mysql host> \
   -e MYSQL_PORT_3306_TCP_PORT=<mysql port> \
   -e MYSQL_DATABASE=<mysql database> \
@@ -136,7 +136,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-p 80` | Snipe-IT Web UI |
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
-| `-e APP_URL=<hostname or ip>` | Hostname or IP and port if applicable IE <ip or hostname>:8080 |
+| `-e NGINX_APP_URL=<hostname or ip>` | Hostname or IP and port if applicable IE <ip or hostname>:8080 |
 | `-e MYSQL_PORT_3306_TCP_ADDR=<mysql host>` | Mysql hostname or IP to use |
 | `-e MYSQL_PORT_3306_TCP_PORT=<mysql port>` | Mysql port to use |
 | `-e MYSQL_DATABASE=<mysql database>` | Mysql database to use |

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -103,6 +103,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "30.04.21:", desc: "Rebasing to alpine 3.13, add artisan migrate on spinup." }
   - { date: "01.06.20:", desc: "Rebasing to alpine 3.12." }
   - { date: "19.12.19:", desc: "Rebasing to alpine 3.11." }
   - { date: "28.06.19:", desc: "Rebasing to alpine 3.10." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -24,7 +24,7 @@ param_ports:
   - { external_port: "8080", internal_port: "80", port_desc: "Snipe-IT Web UI" }
 param_usage_include_env: true
 param_env_vars:
-  - { env_var: "APP_URL", env_value: "<hostname or ip>", desc: "Hostname or IP and port if applicable IE <ip or hostname>:8080"}
+  - { env_var: "NGINX_APP_URL", env_value: "<hostname or ip>", desc: "Hostname or IP and port if applicable IE <ip or hostname>:8080"}
   - { env_var: "MYSQL_PORT_3306_TCP_ADDR", env_value: "<mysql host>", desc: "Mysql hostname or IP to use"}
   - { env_var: "MYSQL_PORT_3306_TCP_PORT", env_value: "<mysql port>", desc: "Mysql port to use"}
   - { env_var: "MYSQL_DATABASE", env_value: "<mysql database>", desc: "Mysql database to use"}
@@ -85,7 +85,7 @@ custom_compose: |
       volumes:
         - <path to data>:/config
       environment:
-        - APP_URL=< your application URL IE 192.168.10.1:8080>
+        - NGINX_APP_URL=< your application URL IE 192.168.10.1:8080>
         - MYSQL_PORT_3306_TCP_ADDR=mysql
         - MYSQL_PORT_3306_TCP_PORT=3306
         - MYSQL_DATABASE=snipe

--- a/root/etc/cont-init.d/40-config
+++ b/root/etc/cont-init.d/40-config
@@ -44,7 +44,7 @@ chown -R abc:abc \
 	/var/www/html/bootstrap/cache
 
 # add server name to nginx config
-sed -i "s/APP_URL_PLACEHOLDER/${APP_URL}/g" /config/nginx/site-confs/default
+sed -i "s/APP_URL_PLACEHOLDER/${NGINX_APP_URL}/g" /config/nginx/site-confs/default
 
 # If the Oauth DB files are not present copy the vendor files over to the db migrations
 if [ ! -f "/var/www/html/database/migrations/*create_oauth*" ]; then

--- a/root/etc/cont-init.d/40-config
+++ b/root/etc/cont-init.d/40-config
@@ -50,3 +50,8 @@ sed -i "s/APP_URL_PLACEHOLDER/${APP_URL}/g" /config/nginx/site-confs/default
 if [ ! -f "/var/www/html/database/migrations/*create_oauth*" ]; then
   cp -ax /var/www/html/vendor/laravel/passport/database/migrations/* /var/www/html/database/migrations/
 fi
+
+# If this container is setup run migrate
+if [ -f /config/storage/oauth-public.key ]; then
+  php /var/www/html/artisan migrate --force
+fi


### PR DESCRIPTION
Multiple fixes: 
* change env variable to not conflict with software reading APP_URL (fixes image uploads)
* rebased to ALpine 3.13 now that the app supports newer PHP
* Run artisan migrate on container spinup if the user has setup their database

Did basic loop testing including a clean container and one that is upgraded. The Env var change will not effect current users, but if they want to fix uploads they will have to change it in their compose/run commands, really no way around it without doing hacky stuff with env vars, better to rip the band aid off. 