### PR TITLE
PHP uploaded file size limit raise

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ services:
       - MYSQL_PASSWORD=<secret user password>
       - PGID=1000
       - PUID=1000
+      - PHP_MAX_UPLOAD_FILESIZE=2M
+      - PHP_POST_MAX_SIZE=8M
     ports:
       - "8080:80"
 
@@ -119,6 +121,8 @@ docker run -d \
   -e MYSQL_DATABASE=<mysql database> \
   -e MYSQL_USER=<mysql pass> \
   -e MYSQL_PASSWORD=changeme \
+  -e PHP_MAX_UPLOAD_FILESIZE=<size>M \
+  -e PHP_POST_MAX_SIZE=<size>M \
   -p 8080:80 \
   -v <path to snipe-it data>:/config \
   --restart unless-stopped \
@@ -140,6 +144,8 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e MYSQL_DATABASE=<mysql database>` | Mysql database to use |
 | `-e MYSQL_USER=<mysql pass>` | Mysql user to use |
 | `-e MYSQL_PASSWORD=changeme` | Mysql password to use |
+| `-e PHP_MAX_UPLOAD_FILESIZE=<size>M` | Maximum size of uploaded file size in php, default 2M |
+| `-e PHP_POST_MAX_SIZE=<size>M` | Maximum size of http POST request in php, default 8M |
 | `-v /config` | Contains your config files and data storage for Snipe-IT |
 
 ## Environment variables from files (Docker secrets)

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -30,6 +30,9 @@ param_env_vars:
   - { env_var: "MYSQL_DATABASE", env_value: "<mysql database>", desc: "Mysql database to use"}
   - { env_var: "MYSQL_USER", env_value: "<mysql pass>", desc: "Mysql user to use"}
   - { env_var: "MYSQL_PASSWORD", env_value: "changeme", desc: "Mysql password to use"}
+  - { env_var: "PHP_MAX_UPLOAD_FILESIZE", env_value: "changeme", desc: "php max_upload_filesize value, default 2M"}
+  - { env_var: "PHP_POST_MAX_SIZE", env_value: "changeme", desc: "php post_max_size value, default 8M"}
+
 
 optional_parameters: |
   This container also generates an SSL certificate and stores it in
@@ -93,6 +96,8 @@ custom_compose: |
         - MYSQL_PASSWORD=<secret user password>
         - PGID=1000
         - PUID=1000
+        - PHP_MAX_UPLOAD_FILESIZE=2M
+        - PHP_POST_MAX_SIZE=8M
       ports:
         - "8080:80"
 

--- a/root/etc/cont-init.d/40-config
+++ b/root/etc/cont-init.d/40-config
@@ -46,6 +46,10 @@ chown -R abc:abc \
 # add server name to nginx config
 sed -i "s/APP_URL_PLACEHOLDER/${NGINX_APP_URL}/g" /config/nginx/site-confs/default
 
+# set PHP variables
+sed -i "s/#PHP_POST_MAX_SIZE_PLACEHOLDER#/${PHP_POST_MAX_SIZE:-8M}/" /etc/php7/conf.d/snipe-local.ini
+sed -i "s/#PHP_UPLOAD_MAX_FILESIZE_PLACEHOLDER#/${PHP_UPLOAD_MAX_FILESIZE:-2M}/" /etc/php7/conf.d/snipe-local.ini
+
 # If the Oauth DB files are not present copy the vendor files over to the db migrations
 if [ ! -f "/var/www/html/database/migrations/*create_oauth*" ]; then
   cp -ax /var/www/html/vendor/laravel/passport/database/migrations/* /var/www/html/database/migrations/

--- a/root/etc/php7/conf.d/snipe-local.ini
+++ b/root/etc/php7/conf.d/snipe-local.ini
@@ -1,5 +1,7 @@
 [PHP]
 variables_order = "EGPCS"
+upload_max_filesize = #PHP_UPLOAD_MAX_FILESIZE_PLACEHOLDER#
+post_max_size = #PHP_POST_MAX_SIZE_PLACEHOLDER#
 [opcache]
 opcache.enable=1
 opcache.enable_cli=1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-snipe-it/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Modify upload_max_filesize and post_max_size in php from environment variable on container start.

## Benefits of this PR and context:
If you have to upload bigger files than 2M (default value) you can't do this at the moment.
A better image about the asset or a pdf/manual could be stored there.

## How Has This Been Tested?
Built the image locally and started it with the new environment variables.
After this, checked the ini_get("upload_max_filesize") and ini_get("post_max_size") values, and it's changed. Also could upload bigger file in the application.
Tested on Arch Linux with Docker 20.10.10
