### PR TITLE
rework init logic update readme and reformat files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,6 @@ ARG SNIPEIT_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="TheLamer"
 
-ENV NGINX_APP_URL=localhost:8080 \
-    DATABASE=mysql
-
 RUN \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,69 +5,71 @@ ARG BUILD_DATE
 ARG VERSION
 ARG SNIPEIT_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="TheLamer, sparkyballs"
+LABEL maintainer="TheLamer"
+
+ENV NGINX_APP_URL=localhost:8080 \
+    DATABASE=mysql
 
 RUN \
- echo "**** install runtime packages ****" && \
- apk add --no-cache \
-	curl \
-	libxml2 \
-	mariadb-client \
-	php7-bcmath \
-	php7-ctype \
-	php7-curl \
-	php7-gd \
-	php7-iconv \
-	php7-ldap \
-	php7-mbstring \
-	php7-mcrypt \
-	php7-phar \
-	php7-pdo_mysql \
-	php7-pdo_sqlite \
-	php7-sqlite3 \
-	php7-tokenizer \
-	php7-xml \
-	php7-xmlreader \
-	php7-zip \
-	tar \
-	unzip && \
- echo "**** configure php-fpm to pass env vars ****" && \
- sed -i \
-	's/;clear_env = no/clear_env = no/g' \
- /etc/php7/php-fpm.d/www.conf && \
- echo "env[PATH] = /usr/local/bin:/usr/bin:/bin" >> /etc/php7/php-fpm.conf && \
- echo "**** install snipe-it ****" && \
- mkdir -p \
-	/var/www/html/ && \
- if [ -z ${SNIPEIT_RELEASE+x} ]; then \
-	SNIPEIT_RELEASE=$(curl -sX GET "https://api.github.com/repos/snipe/snipe-it/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
- fi && \
- curl -o \
- /tmp/snipeit.tar.gz -L \
-	"https://github.com/snipe/snipe-it/archive/${SNIPEIT_RELEASE}.tar.gz" && \
- tar xf \
- /tmp/snipeit.tar.gz -C \
-	/var/www/html/ --strip-components=1 && \
- cp /var/www/html/docker/docker.env /var/www/html/.env && \
- echo "**** install dependencies ****" && \
- cd /tmp && \
- curl -sS https://getcomposer.org/installer | php && \
- mv /tmp/composer.phar /usr/local/bin/composer && \
- composer install -d /var/www/html && \
- echo "**** move storage directories to defaults ****" && \
- mv \
-        "/var/www/html/storage" \
-        "/var/www/html/public/uploads" \
- /defaults/ && \
- echo "**** cleanup ****" && \
- rm -rf \
-	/root/.composer \
-	/tmp/*
+  echo "**** install runtime packages ****" && \
+  apk add --no-cache \
+    curl \
+    libxml2 \
+    mariadb-client \
+    php7-bcmath \
+    php7-ctype \
+    php7-curl \
+    php7-gd \
+    php7-iconv \
+    php7-ldap \
+    php7-mbstring \
+    php7-mcrypt \
+    php7-phar \
+    php7-pdo_mysql \
+    php7-pdo_sqlite \
+    php7-sqlite3 \
+    php7-tokenizer \
+    php7-xml \
+    php7-xmlreader \
+    php7-zip \
+    tar \
+    unzip && \
+  echo "**** configure php-fpm to pass env vars ****" && \
+  sed -i \
+    's/;clear_env = no/clear_env = no/g' \
+    /etc/php7/php-fpm.d/www.conf && \
+  echo "env[PATH] = /usr/local/bin:/usr/bin:/bin" >> /etc/php7/php-fpm.conf && \
+  echo "**** install snipe-it ****" && \
+  mkdir -p \
+    /var/www/html/ && \
+  if [ -z ${SNIPEIT_RELEASE+x} ]; then \
+    SNIPEIT_RELEASE=$(curl -sX GET "https://api.github.com/repos/snipe/snipe-it/releases/latest" \
+    | awk '/tag_name/{print $4;exit}' FS='[""]'); \
+  fi && \
+  curl -o \
+  /tmp/snipeit.tar.gz -L \
+    "https://github.com/snipe/snipe-it/archive/${SNIPEIT_RELEASE}.tar.gz" && \
+  tar xf \
+    /tmp/snipeit.tar.gz -C \
+    /var/www/html/ --strip-components=1 && \
+  cp /var/www/html/docker/docker.env /var/www/html/.env && \
+  echo "**** install dependencies ****" && \
+  cd /tmp && \
+  curl -sS https://getcomposer.org/installer | php && \
+  mv /tmp/composer.phar /usr/local/bin/composer && \
+  composer install -d /var/www/html && \
+  echo "**** move storage directories to defaults ****" && \
+  mv \
+    "/var/www/html/storage" \
+    "/var/www/html/public/uploads" \
+  /defaults/ && \
+  echo "**** cleanup ****" && \
+  rm -rf \
+    /root/.composer \
+    /tmp/*
 
 # copy local files
 COPY root/ /
 
 # ports and volumes
 EXPOSE 80 443
-VOLUME ["/config"]

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -7,9 +7,6 @@ ARG SNIPEIT_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="TheLamer"
 
-ENV NGINX_APP_URL=localhost:8080 \
-    DATABASE=mysql
-
 RUN \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -5,69 +5,71 @@ ARG BUILD_DATE
 ARG VERSION
 ARG SNIPEIT_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="TheLamer, sparkyballs"
+LABEL maintainer="TheLamer"
+
+ENV NGINX_APP_URL=localhost:8080 \
+    DATABASE=mysql
 
 RUN \
- echo "**** install runtime packages ****" && \
- apk add --no-cache \
-	curl \
-	libxml2 \
-	mariadb-client \
-	php7-bcmath \
-	php7-ctype \
-	php7-curl \
-	php7-gd \
-	php7-iconv \
-	php7-ldap \
-	php7-mbstring \
-	php7-mcrypt \
-	php7-phar \
-	php7-pdo_mysql \
-	php7-pdo_sqlite \
-	php7-sqlite3 \
-	php7-tokenizer \
-	php7-xml \
-	php7-xmlreader \
-	php7-zip \
-	tar \
-	unzip && \
- echo "**** configure php-fpm to pass env vars ****" && \
- sed -i \
-	's/;clear_env = no/clear_env = no/g' \
- /etc/php7/php-fpm.d/www.conf && \
- echo "env[PATH] = /usr/local/bin:/usr/bin:/bin" >> /etc/php7/php-fpm.conf && \
- echo "**** install snipe-it ****" && \
- mkdir -p \
-	/var/www/html/ && \
- if [ -z ${SNIPEIT_RELEASE+x} ]; then \
-	SNIPEIT_RELEASE=$(curl -sX GET "https://api.github.com/repos/snipe/snipe-it/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
- fi && \
- curl -o \
- /tmp/snipeit.tar.gz -L \
-	"https://github.com/snipe/snipe-it/archive/${SNIPEIT_RELEASE}.tar.gz" && \
- tar xf \
- /tmp/snipeit.tar.gz -C \
-	/var/www/html/ --strip-components=1 && \
- cp /var/www/html/docker/docker.env /var/www/html/.env && \
- echo "**** install dependencies ****" && \
- cd /tmp && \
- curl -sS https://getcomposer.org/installer | php && \
- mv /tmp/composer.phar /usr/local/bin/composer && \
- composer install -d /var/www/html && \
- echo "**** move storage directories to defaults ****" && \
- mv \
-        "/var/www/html/storage" \
-        "/var/www/html/public/uploads" \
- /defaults/ && \
- echo "**** cleanup ****" && \
- rm -rf \
-	/root/.composer \
-	/tmp/*
+  echo "**** install runtime packages ****" && \
+  apk add --no-cache \
+    curl \
+    libxml2 \
+    mariadb-client \
+    php7-bcmath \
+    php7-ctype \
+    php7-curl \
+    php7-gd \
+    php7-iconv \
+    php7-ldap \
+    php7-mbstring \
+    php7-mcrypt \
+    php7-phar \
+    php7-pdo_mysql \
+    php7-pdo_sqlite \
+    php7-sqlite3 \
+    php7-tokenizer \
+    php7-xml \
+    php7-xmlreader \
+    php7-zip \
+    tar \
+    unzip && \
+  echo "**** configure php-fpm to pass env vars ****" && \
+  sed -i \
+    's/;clear_env = no/clear_env = no/g' \
+    /etc/php7/php-fpm.d/www.conf && \
+  echo "env[PATH] = /usr/local/bin:/usr/bin:/bin" >> /etc/php7/php-fpm.conf && \
+  echo "**** install snipe-it ****" && \
+  mkdir -p \
+    /var/www/html/ && \
+  if [ -z ${SNIPEIT_RELEASE+x} ]; then \
+    SNIPEIT_RELEASE=$(curl -sX GET "https://api.github.com/repos/snipe/snipe-it/releases/latest" \
+    | awk '/tag_name/{print $4;exit}' FS='[""]'); \
+  fi && \
+  curl -o \
+  /tmp/snipeit.tar.gz -L \
+    "https://github.com/snipe/snipe-it/archive/${SNIPEIT_RELEASE}.tar.gz" && \
+  tar xf \
+    /tmp/snipeit.tar.gz -C \
+    /var/www/html/ --strip-components=1 && \
+  cp /var/www/html/docker/docker.env /var/www/html/.env && \
+  echo "**** install dependencies ****" && \
+  cd /tmp && \
+  curl -sS https://getcomposer.org/installer | php && \
+  mv /tmp/composer.phar /usr/local/bin/composer && \
+  composer install -d /var/www/html && \
+  echo "**** move storage directories to defaults ****" && \
+  mv \
+    "/var/www/html/storage" \
+    "/var/www/html/public/uploads" \
+  /defaults/ && \
+  echo "**** cleanup ****" && \
+  rm -rf \
+    /root/.composer \
+    /tmp/*
 
 # copy local files
 COPY root/ /
 
 # ports and volumes
 EXPOSE 80 443
-VOLUME ["/config"]

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -7,9 +7,6 @@ ARG SNIPEIT_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="TheLamer"
 
-ENV NGINX_APP_URL=localhost:8080 \
-    DATABASE=mysql
-
 RUN \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -5,69 +5,71 @@ ARG BUILD_DATE
 ARG VERSION
 ARG SNIPEIT_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="TheLamer, sparkyballs"
+LABEL maintainer="TheLamer"
+
+ENV NGINX_APP_URL=localhost:8080 \
+    DATABASE=mysql
 
 RUN \
- echo "**** install runtime packages ****" && \
- apk add --no-cache \
-	curl \
-	libxml2 \
-	mariadb-client \
-	php7-bcmath \
-	php7-ctype \
-	php7-curl \
-	php7-gd \
-	php7-iconv \
-	php7-ldap \
-	php7-mbstring \
-	php7-mcrypt \
-	php7-phar \
-	php7-pdo_mysql \
-	php7-pdo_sqlite \
-	php7-sqlite3 \
-	php7-tokenizer \
-	php7-xml \
-	php7-xmlreader \
-	php7-zip \
-	tar \
-	unzip && \
- echo "**** configure php-fpm to pass env vars ****" && \
- sed -i \
-	's/;clear_env = no/clear_env = no/g' \
- /etc/php7/php-fpm.d/www.conf && \
- echo "env[PATH] = /usr/local/bin:/usr/bin:/bin" >> /etc/php7/php-fpm.conf && \
- echo "**** install snipe-it ****" && \
- mkdir -p \
-	/var/www/html/ && \
- if [ -z ${SNIPEIT_RELEASE+x} ]; then \
-	SNIPEIT_RELEASE=$(curl -sX GET "https://api.github.com/repos/snipe/snipe-it/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
- fi && \
- curl -o \
- /tmp/snipeit.tar.gz -L \
-	"https://github.com/snipe/snipe-it/archive/${SNIPEIT_RELEASE}.tar.gz" && \
- tar xf \
- /tmp/snipeit.tar.gz -C \
-	/var/www/html/ --strip-components=1 && \
- cp /var/www/html/docker/docker.env /var/www/html/.env && \
- echo "**** install dependencies ****" && \
- cd /tmp && \
- curl -sS https://getcomposer.org/installer | php && \
- mv /tmp/composer.phar /usr/local/bin/composer && \
- composer install -d /var/www/html && \
- echo "**** move storage directories to defaults ****" && \
- mv \
-        "/var/www/html/storage" \
-        "/var/www/html/public/uploads" \
- /defaults/ && \
- echo "**** cleanup ****" && \
- rm -rf \
-	/root/.composer \
-	/tmp/*
+  echo "**** install runtime packages ****" && \
+  apk add --no-cache \
+    curl \
+    libxml2 \
+    mariadb-client \
+    php7-bcmath \
+    php7-ctype \
+    php7-curl \
+    php7-gd \
+    php7-iconv \
+    php7-ldap \
+    php7-mbstring \
+    php7-mcrypt \
+    php7-phar \
+    php7-pdo_mysql \
+    php7-pdo_sqlite \
+    php7-sqlite3 \
+    php7-tokenizer \
+    php7-xml \
+    php7-xmlreader \
+    php7-zip \
+    tar \
+    unzip && \
+  echo "**** configure php-fpm to pass env vars ****" && \
+  sed -i \
+    's/;clear_env = no/clear_env = no/g' \
+    /etc/php7/php-fpm.d/www.conf && \
+  echo "env[PATH] = /usr/local/bin:/usr/bin:/bin" >> /etc/php7/php-fpm.conf && \
+  echo "**** install snipe-it ****" && \
+  mkdir -p \
+    /var/www/html/ && \
+  if [ -z ${SNIPEIT_RELEASE+x} ]; then \
+    SNIPEIT_RELEASE=$(curl -sX GET "https://api.github.com/repos/snipe/snipe-it/releases/latest" \
+    | awk '/tag_name/{print $4;exit}' FS='[""]'); \
+  fi && \
+  curl -o \
+  /tmp/snipeit.tar.gz -L \
+    "https://github.com/snipe/snipe-it/archive/${SNIPEIT_RELEASE}.tar.gz" && \
+  tar xf \
+    /tmp/snipeit.tar.gz -C \
+    /var/www/html/ --strip-components=1 && \
+  cp /var/www/html/docker/docker.env /var/www/html/.env && \
+  echo "**** install dependencies ****" && \
+  cd /tmp && \
+  curl -sS https://getcomposer.org/installer | php && \
+  mv /tmp/composer.phar /usr/local/bin/composer && \
+  composer install -d /var/www/html && \
+  echo "**** move storage directories to defaults ****" && \
+  mv \
+    "/var/www/html/storage" \
+    "/var/www/html/public/uploads" \
+  /defaults/ && \
+  echo "**** cleanup ****" && \
+  rm -rf \
+    /root/.composer \
+    /tmp/*
 
 # copy local files
 COPY root/ /
 
 # ports and volumes
 EXPOSE 80 443
-VOLUME ["/config"]

--- a/README.md
+++ b/README.md
@@ -61,6 +61,42 @@ The architectures supported by this image are:
 ## Application Setup
 
 Access the webui at `<your-ip>:8080`, for more information check out [Snipe-it](https://github.com/snipe/snipe-it).
+**This container requires a MySQL or MariaDB server to connect to, we reccomend [ours](https://github.com/linuxserver/docker-mariadb)**
+
+This container also generates an SSL certificate and stores it in
+```
+/config/keys/cert.crt
+/config/keys/key.crt
+```
+To use your own certificate swap these files with yours. To use SSL forward your port to 443 inside the container IE:
+
+```
+-p 443:443
+```
+
+The application accepts a series of environment variables to further customize itself on boot:
+
+| Parameter | Function |
+| :---: | --- |
+| `-e APP_ENV=` | Default is production but can use testing or develop|
+| `-e APP_DEBUG=` | Set to true to see debugging output in the web UI|
+| `-e APP_LOCALE=` | Default is en set to the language preferred full list [here](https://snipe-it.readme.io/docs/configuration#section-setting-a-language)|
+| `-e MAIL_PORT_587_TCP_ADDR=` | SMTP mailserver ip or hostname|
+| `-e MAIL_PORT_587_TCP_PORT=` | SMTP mailserver port|
+| `-e MAIL_ENV_FROM_ADDR=` | The email address mail should be replied to and listed when sent|
+| `-e MAIL_ENV_FROM_NAME=` | The name listed on email sent from the default account on the system|
+| `-e MAIL_ENV_ENCRYPTION=` | Mail encryption to use IE tls |
+| `-e MAIL_ENV_USERNAME=` | SMTP server login username|
+| `-e MAIL_ENV_PASSWORD=` | SMTP server login password|
+
+### PHP customization
+
+This image uses our NGINX base image all configuration files for PHP and NGINX are located in `/config/php`. To overide any defaults please modify `/config/php/php-local.ini` IE for upload size: 
+
+```
+upload_max_filesize = 16
+post_max_size = 16M
+```
 
 ## Usage
 
@@ -69,42 +105,27 @@ Here are some example snippets to help you get started creating a container.
 ### docker-compose (recommended, [click here for more info](https://docs.linuxserver.io/general/docker-compose))
 
 ```yaml
-version: "3"
+---
+version: "2.1"
 services:
-  mysql:
-    image: linuxserver/mariadb
-    container_name: snipe_mysql
-    restart: always
-    volumes:
-      - <path to mysql data>:/config
-    environment:
-      - PUID=1000
-      - PGID=1000
-      - TZ=Europe/London
-      - MYSQL_ROOT_PASSWORD=<secret password>
-      - MYSQL_USER=snipe
-      - MYSQL_PASSWORD=<secret user password>
-      - MYSQL_DATABASE=snipe
-  snipeit:
-    image: linuxserver/snipe-it:latest
+  snipe-it:
+    image: lscr.io/linuxserver/snipe-it
     container_name: snipe-it
-    restart: always
-    depends_on:
-      - mysql
-    volumes:
-      - <path to data>:/config
     environment:
-      - NGINX_APP_URL=< your application URL IE 192.168.10.1:8080>
-      - MYSQL_PORT_3306_TCP_ADDR=mysql
-      - MYSQL_PORT_3306_TCP_PORT=3306
-      - MYSQL_DATABASE=snipe
-      - MYSQL_USER=snipe
-      - MYSQL_PASSWORD=<secret user password>
-      - PGID=1000
       - PUID=1000
+      - PGID=1000
+      - APP_URL=http://localhost:8080
+      - MYSQL_PORT_3306_TCP_ADDR=<mysql host>
+      - MYSQL_PORT_3306_TCP_PORT=<mysql port>
+      - MYSQL_DATABASE=<mysql database>
+      - MYSQL_USER=<mysql pass>
+      - MYSQL_PASSWORD=changeme
+      - TZ=US/Pacific
+    volumes:
+      - <path to snipe-it data>:/config
     ports:
-      - "8080:80"
-
+      - 8080:80
+    restart: unless-stopped
 ```
 
 ### docker cli ([click here for more info](https://docs.docker.com/engine/reference/commandline/cli/))
@@ -114,12 +135,13 @@ docker run -d \
   --name=snipe-it \
   -e PUID=1000 \
   -e PGID=1000 \
-  -e NGINX_APP_URL=<hostname or ip> \
+  -e APP_URL=http://localhost:8080 \
   -e MYSQL_PORT_3306_TCP_ADDR=<mysql host> \
   -e MYSQL_PORT_3306_TCP_PORT=<mysql port> \
   -e MYSQL_DATABASE=<mysql database> \
   -e MYSQL_USER=<mysql pass> \
   -e MYSQL_PASSWORD=changeme \
+  -e TZ=US/Pacific \
   -p 8080:80 \
   -v <path to snipe-it data>:/config \
   --restart unless-stopped \
@@ -135,12 +157,13 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-p 80` | Snipe-IT Web UI |
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
-| `-e NGINX_APP_URL=<hostname or ip>` | Hostname or IP and port if applicable IE <ip or hostname>:8080 |
+| `-e APP_URL=http://localhost:8080` | Hostname or IP and port if applicable, be sure to define https/http |
 | `-e MYSQL_PORT_3306_TCP_ADDR=<mysql host>` | Mysql hostname or IP to use |
 | `-e MYSQL_PORT_3306_TCP_PORT=<mysql port>` | Mysql port to use |
 | `-e MYSQL_DATABASE=<mysql database>` | Mysql database to use |
 | `-e MYSQL_USER=<mysql pass>` | Mysql user to use |
 | `-e MYSQL_PASSWORD=changeme` | Mysql password to use |
+| `-e TZ=US/Pacific` | Specify a timezone to use EG Europe/London, this is required to run snipe-it |
 | `-v /config` | Contains your config files and data storage for Snipe-IT |
 
 ## Environment variables from files (Docker secrets)
@@ -159,35 +182,6 @@ Will set the environment variable `PASSWORD` based on the contents of the `/run/
 
 For all of our images we provide the ability to override the default umask settings for services started within the containers using the optional `-e UMASK=022` setting.
 Keep in mind umask is not chmod it subtracts from permissions based on it's value it does not add. Please read up [here](https://en.wikipedia.org/wiki/Umask) before asking for support.
-
-## Optional Parameters
-
-This container also generates an SSL certificate and stores it in
-```
-/config/keys/cert.crt
-/config/keys/key.crt
-```
-To use your own certificate swap these files with yours. To use SSL forward your port to 443 inside the container IE:
-
-```
--p 443:443
-```
-
-The application accepts a series of environment variables to further customize itself on boot:
-
-| Parameter | Function |
-| :---: | --- |
-| `-e APP_TIMEZONE=` | The timezone the application will use IE US/Pacific|
-| `-e APP_ENV=` | Default is production but can use testing or develop|
-| `-e APP_DEBUG=` | Set to true to see debugging output in the web UI|
-| `-e APP_LOCALE=` | Default is en set to the language preferred full list [here][localesurl]|
-| `-e MAIL_PORT_587_TCP_ADDR=` | SMTP mailserver ip or hostname|
-| `-e MAIL_PORT_587_TCP_PORT=` | SMTP mailserver port|
-| `-e MAIL_ENV_FROM_ADDR=` | The email address mail should be replied to and listed when sent|
-| `-e MAIL_ENV_FROM_NAME=` | The name listed on email sent from the default account on the system|
-| `-e MAIL_ENV_ENCRYPTION=` | Mail encryption to use IE tls |
-| `-e MAIL_ENV_USERNAME=` | SMTP server login username|
-| `-e MAIL_ENV_PASSWORD=` | SMTP server login password|
 
 ## User / Group Identifiers
 
@@ -281,6 +275,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **02.03.22:** - Rework init logic, do not show default compose.
 * **29.06.21:** - Rebasing to alpine 3.14.
 * **30.04.21:** - Rebasing to alpine 3.13, add artisan migrate on spinup.
 * **01.06.20:** - Rebasing to alpine 3.12.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -24,14 +24,20 @@ param_ports:
   - { external_port: "8080", internal_port: "80", port_desc: "Snipe-IT Web UI" }
 param_usage_include_env: true
 param_env_vars:
-  - { env_var: "NGINX_APP_URL", env_value: "<hostname or ip>", desc: "Hostname or IP and port if applicable IE <ip or hostname>:8080"}
+  - { env_var: "APP_URL", env_value: "http://localhost:8080", desc: "Hostname or IP and port if applicable, be sure to define https/http"}
   - { env_var: "MYSQL_PORT_3306_TCP_ADDR", env_value: "<mysql host>", desc: "Mysql hostname or IP to use"}
   - { env_var: "MYSQL_PORT_3306_TCP_PORT", env_value: "<mysql port>", desc: "Mysql port to use"}
   - { env_var: "MYSQL_DATABASE", env_value: "<mysql database>", desc: "Mysql database to use"}
   - { env_var: "MYSQL_USER", env_value: "<mysql pass>", desc: "Mysql user to use"}
   - { env_var: "MYSQL_PASSWORD", env_value: "changeme", desc: "Mysql password to use"}
+  - { env_var: "TZ", env_value: "US/Pacific", desc: "Specify a timezone to use EG Europe/London, this is required to run snipe-it"}
 
-optional_parameters: |
+# application setup block
+app_setup_block_enabled: true
+app_setup_block: |
+  Access the webui at `<your-ip>:8080`, for more information check out [{{ project_name|capitalize }}]({{ project_url }}).
+  **This container requires a MySQL or MariaDB server to connect to, we reccomend [ours](https://github.com/linuxserver/docker-mariadb)**
+
   This container also generates an SSL certificate and stores it in
   ```
   /config/keys/cert.crt
@@ -47,10 +53,9 @@ optional_parameters: |
 
   | Parameter | Function |
   | :---: | --- |
-  | `-e APP_TIMEZONE=` | The timezone the application will use IE US/Pacific|
   | `-e APP_ENV=` | Default is production but can use testing or develop|
   | `-e APP_DEBUG=` | Set to true to see debugging output in the web UI|
-  | `-e APP_LOCALE=` | Default is en set to the language preferred full list [here][localesurl]|
+  | `-e APP_LOCALE=` | Default is en set to the language preferred full list [here](https://snipe-it.readme.io/docs/configuration#section-setting-a-language)|
   | `-e MAIL_PORT_587_TCP_ADDR=` | SMTP mailserver ip or hostname|
   | `-e MAIL_PORT_587_TCP_PORT=` | SMTP mailserver port|
   | `-e MAIL_ENV_FROM_ADDR=` | The email address mail should be replied to and listed when sent|
@@ -59,50 +64,18 @@ optional_parameters: |
   | `-e MAIL_ENV_USERNAME=` | SMTP server login username|
   | `-e MAIL_ENV_PASSWORD=` | SMTP server login password|
 
-custom_compose: |
-  version: "3"
-  services:
-    mysql:
-      image: linuxserver/mariadb
-      container_name: snipe_mysql
-      restart: always
-      volumes:
-        - <path to mysql data>:/config
-      environment:
-        - PUID=1000
-        - PGID=1000
-        - TZ=Europe/London
-        - MYSQL_ROOT_PASSWORD=<secret password>
-        - MYSQL_USER=snipe
-        - MYSQL_PASSWORD=<secret user password>
-        - MYSQL_DATABASE=snipe
-    snipeit:
-      image: linuxserver/snipe-it:latest
-      container_name: snipe-it
-      restart: always
-      depends_on:
-        - mysql
-      volumes:
-        - <path to data>:/config
-      environment:
-        - NGINX_APP_URL=< your application URL IE 192.168.10.1:8080>
-        - MYSQL_PORT_3306_TCP_ADDR=mysql
-        - MYSQL_PORT_3306_TCP_PORT=3306
-        - MYSQL_DATABASE=snipe
-        - MYSQL_USER=snipe
-        - MYSQL_PASSWORD=<secret user password>
-        - PGID=1000
-        - PUID=1000
-      ports:
-        - "8080:80"
+  ### PHP customization
 
-# application setup block
-app_setup_block_enabled: true
-app_setup_block: |
-  Access the webui at `<your-ip>:8080`, for more information check out [{{ project_name|capitalize }}]({{ project_url }}).
+  This image uses our NGINX base image all configuration files for PHP and NGINX are located in `/config/php`. To overide any defaults please modify `/config/php/php-local.ini` IE for upload size: 
+  
+  ```
+  upload_max_filesize = 16
+  post_max_size = 16M
+  ```
 
 # changelog
 changelogs:
+  - { date: "02.03.22:", desc: "Rework init logic, do not show default compose." }
   - { date: "29.06.21:", desc: "Rebasing to alpine 3.14." }
   - { date: "30.04.21:", desc: "Rebasing to alpine 3.13, add artisan migrate on spinup." }
   - { date: "01.06.20:", desc: "Rebasing to alpine 3.12." }

--- a/root/etc/cont-init.d/40-config
+++ b/root/etc/cont-init.d/40-config
@@ -2,34 +2,32 @@
 
 # create folders
 mkdir -p \
-	/config/storage \
-	/config/uploads
+  /config/storage \
+  /config/uploads
 
 # copy config files
 PREV_DIR=$(pwd)
 
-	cd /defaults/storage || exit
-	shopt -s globstar nullglob
-	for i in *
- 	do
-	[[ ! -e "/config/storage/${i}" ]] && cp -r "${i}" "/config/storage/${i}"
-	done
+cd /defaults/storage || exit
+shopt -s globstar nullglob
+for i in *; do
+  [[ ! -e "/config/storage/${i}" ]] && cp -r "${i}" "/config/storage/${i}"
+done
 
-	cd /defaults/uploads || exit
-	shopt -s globstar nullglob
-	for i in *
- 	do
-	[[ ! -e "/config/uploads/${i}" ]] && cp -r "${i}" "/config/uploads/${i}"
-	done
+cd /defaults/uploads || exit
+shopt -s globstar nullglob
+for i in *; do
+  [[ ! -e "/config/uploads/${i}" ]] && cp -r "${i}" "/config/uploads/${i}"
+done
 cd "${PREV_DIR}" || exit
 
 # make symlinks
 [[ ! -L /var/www/html/storage ]] && \
-	ln -sf /config/storage /var/www/html/storage
+  ln -sf /config/storage /var/www/html/storage
 [[ ! -L /var/www/html/public/uploads ]] && \
-	ln -sf /config/uploads /var/www/html/public/uploads
+  ln -sf /config/uploads /var/www/html/public/uploads
 
-# Create API key if needed
+# create API key if needed
 if [ ! -f "/config/SNIPE_IT_APP_KEY.txt" ]
 then
   echo "Generating SnipeIT app key for first run"
@@ -40,18 +38,32 @@ fi
 
 # permissions
 chown -R abc:abc \
-	/config/ \
-	/var/www/html/bootstrap/cache
+  /config/ \
+  /var/www/html/bootstrap/cache
 
-# add server name to nginx config
-sed -i "s/APP_URL_PLACEHOLDER/${NGINX_APP_URL}/g" /config/nginx/site-confs/default
+# add server name to nginx config while handling legacy settings
+if [ ! -z ${NGINX_APP_URL+x} ]; then
+  REPLACE_URL=${NGINX_APP_URL}
+fi
+if [ ! -z ${NGINX_APP_URL+x} ] && [ -z ${APP_URL+x} ]; then
+  printf "http://${NGINX_APP_URL}" > /run/s6/container_environment/APP_URL
+fi
+if [ -z ${NGINX_APP_URL+x} ] && [ ! -z ${APP_URL+x} ]; then
+  REPLACE_URL=$(echo ${APP_URL} | awk -F/ '{print $3}')
+fi
+sed -i "s/APP_URL_PLACEHOLDER/${REPLACE_URL}/g" /config/nginx/site-confs/default
 
-# If the Oauth DB files are not present copy the vendor files over to the db migrations
+# if the Oauth DB files are not present copy the vendor files over to the db migrations
 if [ ! -f "/var/www/html/database/migrations/*create_oauth*" ]; then
   cp -ax /var/www/html/vendor/laravel/passport/database/migrations/* /var/www/html/database/migrations/
 fi
 
-# If this container is setup run migrate
+# if this container is setup run migrate
 if [ -f /config/storage/oauth-public.key ]; then
   php /var/www/html/artisan migrate --force
+fi
+
+# copy over timezone env var
+if [ ! -z ${TZ+x} ]; then
+  printf ${TZ} > /run/s6/container_environment/APP_TIMEZONE
 fi


### PR DESCRIPTION
closes #35
closes #30 
closes #25 
closes #20
closes #32 

The NGINX_APP_URL param implemented does not work anymore and APP_URL is required now. This change ensures that people using just NGINX_APP_URL or APP_URL or both will still be functional with all the correct settings. 

I also pulled out the custom compose stuff and allow user to set timezone. 
